### PR TITLE
Fix: Configure project as ES Module to resolve Netlify build error

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "src",
   "version": "0.1.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "dev": "next dev",
     "build": "next build",


### PR DESCRIPTION
The Netlify deployment was failing with a syntax error: "'import', and 'export' cannot be used outside of module code" in `lib/network-utils.ts`.

This error occurred because the project was not explicitly defined as an ES Module project, and Node.js was defaulting to CommonJS, which does not support `import`/`export` syntax in `.ts` files in this context.

This commit resolves the issue by adding `"type": "module"` to the `package.json` file. This change instructs Node.js (and by extension, the Next.js build process used by Netlify) to treat JavaScript and TypeScript files as ES modules, thus allowing the use of `import` and `export` statements.