### PR TITLE
Refactor: Prevent premature endSession in useUltravoxSession

### DIFF
--- a/hooks/useUltravoxSession.ts
+++ b/hooks/useUltravoxSession.ts
@@ -296,12 +296,20 @@ export function useUltravoxSession({
 
   // Cleanup on unmount
   useEffect(() => {
+    // This effect runs once on mount to set up the cleanup
     return () => {
-      if (sessionRef.current) {
-        endSession();
+      // This cleanup runs ONLY on component unmount
+      const sessionToClean = sessionRef.current;
+      if (sessionToClean && typeof sessionToClean.leaveCall === 'function') {
+        console.log('[Ultravox] useEffect unmount cleanup: Component is unmounting. Leaving call if session exists.');
+        sessionToClean.leaveCall().catch((err: any) => { // Call leaveCall directly on the ref's value
+          console.error('[Ultravox] Error in unmount cleanup (leaveCall):', err);
+          // Potentially call onErrorCallback here if appropriate for unmount errors
+          onError(err instanceof Error ? err : new Error(String(err))); // Pass the onError prop to the hook.
+        });
       }
     };
-  }, [endSession]);
+  }, []); // EMPTY DEPENDENCY ARRAY ensures this cleanup only runs on unmount
 
   return {
     session,


### PR DESCRIPTION
This commit addresses an issue where the `endSession` function was being called prematurely due to a `useEffect` cleanup hook.

The key changes are:

1.  The `useEffect` hook responsible for unmount cleanup now has an empty dependency array (`[]`). This ensures that the cleanup logic only runs when the component using the hook actually unmounts.
2.  The cleanup function within this `useEffect` now directly calls `sessionRef.current.leaveCall()` instead of `endSession()`. This makes the cleanup self-contained and avoids potential issues with stale closures or unintended calls to `endSession` caused by changes in its reference.
3.  The `endSession` function itself, defined with `useCallback([onError])`, is considered stable, assuming the `onError` prop provided to the hook is stable. The primary fix was to decouple the unmount cleanup from `endSession`'s reference stability.

These changes prevent the previously observed loop and ensure that `leaveCall` is only invoked during component unmount or when `endSession` is manually called by the parent component.