### PR TITLE
Fix: Correct duplicated variable declaration in useUltravoxSession

### DIFF
--- a/hooks/useUltravoxSession.ts
+++ b/hooks/useUltravoxSession.ts
@@ -148,7 +148,6 @@ export function useUltravoxSession({
         }
 
         const eventTargetEndReason = event.target?.endReason;
-        const eventTargetEndReason = event.target?.endReason;
 
         console.log(`[Ultravox] Status Event. Current: ${currentStatus}, Previous: ${prevStatusRef.current}, SDK Reason: ${eventTargetEndReason || 'N/A'}. Raw event:`, event);
         


### PR DESCRIPTION
Removes a duplicated declaration of the 'eventTargetEndReason' variable within the 'localHandleStatusUpdate' function in 'hooks/useUltravoxSession.ts'.

This fixes a "Identifier 'eventTargetEndReason' has already been declared" build error that occurred during Netlify deployment.