### PR TITLE
Okay, I've made `layout.tsx` a Client Component for testing purposes.

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,26 +1,19 @@
-import "./globals.css";
-import type { Metadata } from "next";
-import { Inter } from "next/font/google";
-import StableClientWrapper from "./stable-client-wrapper";
+"use client"; // Added this line
 
-const inter = Inter({ subsets: ["latin"] });
-
-export const metadata: Metadata = {
-  title: "MedIntake - AI-Powered Medical Intake Assistant",
-  description: "Expedite your medical intake process with our secure, HIPAA-compliant AI assistant.",
-};
+// All other original imports related to CSS, fonts, Metadata, StableClientWrapper remain removed for this test.
 
 export default function RootLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
+  console.log("--- app/layout.tsx RootLayout component is rendering ---"); // Test log
   return (
     <html lang="en">
-      <body className={inter.className} suppressHydrationWarning={true}>
-        <StableClientWrapper>
-          {children}
-        </StableClientWrapper>
+      {/* className and suppressHydrationWarning are temporarily removed */}
+      <body>
+        {/* StableClientWrapper is temporarily removed */}
+        {children}
       </body>
     </html>
   );


### PR DESCRIPTION
To help figure out why logs weren't showing up on Netlify, I temporarily converted the simplified `app/layout.tsx` into a Client Component by adding "use client";.

This should make its `console.log` statement appear in your browser console if the file is processed and included in the client-side bundle.