### PR TITLE
Debug: Targeted useEffect log in StableClientWrapper

### DIFF
--- a/app/stable-client-wrapper.tsx
+++ b/app/stable-client-wrapper.tsx
@@ -1,24 +1,22 @@
 "use client";
 
-import { useRef, useEffect } from "react";
+import { useRef, useEffect } from "react"; // useEffect is already here
 
 // Stability wrapper to prevent child component remounting
 function StableWrapper({ children }: { children: React.ReactNode }) {
-  // Use static key for true stability across hydration (better than Date.now())
   const keyRef = useRef('stable-wrapper-key');
   const mountCountRef = useRef(0);
   
   useEffect(() => {
-    mountCountRef.current += 1;
-    console.log(`🔒 StableWrapper Mount #${mountCountRef.current} - Key: ${keyRef.current}`);
+    // mountCountRef.current += 1;
+    // console.log(`🔒 StableWrapper Mount #${mountCountRef.current} - Key: ${keyRef.current}`);
     
-    return () => {
-      console.log(`🔒 StableWrapper Unmount #${mountCountRef.current}`);
-      console.trace('StableWrapper unmount trace - This should only happen on page navigation');
-    };
+    // return () => {
+    //   console.log(`🔒 StableWrapper Unmount #${mountCountRef.current}`);
+    //   console.trace('StableWrapper unmount trace - This should only happen on page navigation');
+    // };
   }, []);
   
-  // This key never changes, preventing child remounting
   return (
     <div key={keyRef.current} style={{ width: '100%', height: '100%', minHeight: '100vh' }}>
       {children}
@@ -31,32 +29,35 @@ function LayoutMountTracker({ children }: { children: React.ReactNode }) {
   const layoutMountCount = useRef(0);
   
   useEffect(() => {
-    layoutMountCount.current += 1;
-    console.log(`🏗️ LayoutMountTracker Mount #${layoutMountCount.current}`);
+    // layoutMountCount.current += 1;
+    // console.log(`🏗️ LayoutMountTracker Mount #${layoutMountCount.current}`);
     
-    // Track what might be causing layout remounts
-    if (typeof window !== 'undefined') {
-      const errorStates = {
-        urlError: window.location.href.includes('error'),
-        localStorageError: !!localStorage.getItem('app-error'),
-        sessionStorageError: !!sessionStorage.getItem('app-error'),
-      };
+    // if (typeof window !== 'undefined') {
+    //   const errorStates = {
+    //     urlError: window.location.href.includes('error'),
+    //     localStorageError: !!localStorage.getItem('app-error'),
+    //     sessionStorageError: !!sessionStorage.getItem('app-error'),
+    //   };
       
-      if (Object.values(errorStates).some(Boolean)) {
-        console.warn('🚨 LayoutMountTracker mounted with error states:', errorStates);
-      }
-    }
+    //   if (Object.values(errorStates).some(Boolean)) {
+    //     console.warn('🚨 LayoutMountTracker mounted with error states:', errorStates);
+    //   }
+    // }
     
-    return () => {
-      console.log(`🏗️ LayoutMountTracker Unmount #${layoutMountCount.current}`);
-      console.trace('LayoutMountTracker unmount trace');
-    };
+    // return () => {
+    //   console.log(`🏗️ LayoutMountTracker Unmount #${layoutMountCount.current}`);
+    //   console.trace('LayoutMountTracker unmount trace');
+    // };
   }, []);
   
   return <>{children}</>;
 }
 
 export default function StableClientWrapper({ children }: { children: React.ReactNode }) {
+  useEffect(() => { // Added this new useEffect
+    console.log('--- TEST LOG FROM StableClientWrapper useEffect ---');
+  }, []);
+
   return (
     <LayoutMountTracker>
       <StableWrapper>


### PR DESCRIPTION
- I've restored app/layout.tsx to its original state.
- I've modified app/stable-client-wrapper.tsx:
  - I commented out existing useEffect logs in StableWrapper and LayoutMountTracker.
  - I added a new, simple useEffect in the main StableClientWrapper export to log a test message.

This is to test if any client-side useEffect from StableClientWrapper runs when used by your original layout.tsx in the Netlify environment.