### PR TITLE
fix: Add missing zustand dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -61,7 +61,8 @@
         "tw-animate-css": "^1.2.5",
         "ultravox-client": "^0.3.6",
         "vaul": "^1.1.2",
-        "zod": "^3.24.2"
+        "zod": "^3.24.2",
+        "zustand": "^5.0.5"
       },
       "devDependencies": {
         "@babel/eslint-parser": "^7.27.1",
@@ -11326,6 +11327,34 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.5.tgz",
+      "integrity": "sha512-mILtRfKW9xM47hqxGIxCv12gXusoY/xTSHBYApXozR0HmQv299whhBeeAcRy+KrPPybzosvJBCOmVjq6x12fCg==",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -68,7 +68,8 @@
     "tw-animate-css": "^1.2.5",
     "ultravox-client": "^0.3.6",
     "vaul": "^1.1.2",
-    "zod": "^3.24.2"
+    "zod": "^3.24.2",
+    "zustand": "^5.0.5"
   },
   "devDependencies": {
     "@babel/eslint-parser": "^7.27.1",


### PR DESCRIPTION
The previous build failed on Netlify due to `zustand` not being installed. This commit adds `zustand` to the `dependencies` in `package.json` and updates the `package-lock.json` file accordingly.