### PR TITLE
Hi there! Here's a summary of the changes I've made:

### DIFF
--- a/components/UltravoxSessionManager.tsx
+++ b/components/UltravoxSessionManager.tsx
@@ -23,124 +23,170 @@ export function UltravoxSessionManager(props: UltravoxSessionManagerProps) {
   const { joinUrl, callId, shouldConnect, ...callbacks } = props;
   const ultravoxSession = useUltravoxSession(callbacks); // Callbacks are passed to the hook
   const hasAttemptedConnectionRef = useRef(false);
-  const performingPreChecksRef = useRef(false);
+  const performingSessionManagementRef = useRef(false); // Renamed for clarity
+  const hasEncounteredErrorRef = useRef(false);
+  const prevJoinUrlRef = useRef<string | null>(null);
+  const prevCallIdRef = useRef<string | null>(null);
 
   useEffect(() => {
-    const effectCallId = callId || 'unknown-call-id'; // Use for logging
-    logger.log('[UltravoxSessionManager] Main effect triggered.', { 
-      shouldConnect, 
-      joinUrlProvided: !!joinUrl, 
-      callIdProvided: !!callId, 
-      hasAttempted: hasAttemptedConnectionRef.current, 
-      isPerformingPreChecks: performingPreChecksRef.current 
+    const effectCallIdLog = callId || 'unknown-call-id'; // Use for logging current callId
+    logger.log('[UltravoxSessionManager] Main effect triggered.', {
+      shouldConnect,
+      joinUrlProvided: !!joinUrl,
+      callIdProvided: !!callId,
+      hasAttempted: hasAttemptedConnectionRef.current,
+      isManaging: performingSessionManagementRef.current,
+      hasError: hasEncounteredErrorRef.current,
+      prevCallId: prevCallIdRef.current,
+      currentCallId: callId,
     });
+
+    // Check if callId or joinUrl has changed, indicating a new session context
+    if (joinUrl !== prevJoinUrlRef.current || callId !== prevCallIdRef.current) {
+      logger.log(`[UltravoxSessionManager] Context change detected (joinUrl or callId changed). Old: ${prevCallIdRef.current}, New: ${effectCallIdLog}. Resetting flags.`, {
+        oldJoinUrl: prevJoinUrlRef.current, newJoinUrl: joinUrl,
+        oldCallId: prevCallIdRef.current, newCallId: callId
+      });
+      hasAttemptedConnectionRef.current = false;
+      hasEncounteredErrorRef.current = false;
+      // No need to reset performingSessionManagementRef here as it guards the async function itself.
+      // Update prev refs to current values
+      prevJoinUrlRef.current = joinUrl;
+      prevCallIdRef.current = callId;
+    }
 
     const performConnectionSequence = async () => {
       if (!joinUrl || !callId) {
-        logger.warn('[UltravoxSessionManager] joinUrl or callId is missing. Cannot connect.');
+        logger.warn('[UltravoxSessionManager] Critical: joinUrl or callId is missing post-check. This should not happen if initial checks are correct.');
+        // This error should ideally be caught by earlier checks in the effect.
+        // If it still happens, it's an unexpected state.
         if(shouldConnect) { // Only error if we actually intended to connect
-            callbacks.onError(new Error('Connection cannot proceed: joinUrl or callId is missing.'), 'PreCheck');
+            callbacks.onError(new Error('Connection cannot proceed: joinUrl or callId became null unexpectedly.'), 'PreCheck');
         }
-        return;
+        return; // Should not proceed.
       }
 
-      if (performingPreChecksRef.current) {
-        logger.log('[UltravoxSessionManager] Pre-checks or connection sequence already in progress. Aborting this run.');
+      // Guard against re-entrancy for the async operations
+      if (performingSessionManagementRef.current) {
+        logger.log('[UltravoxSessionManager] Session management (connection/disconnection) already in progress. Aborting this run.');
         return;
       }
-      performingPreChecksRef.current = true;
-      logger.log(`[UltravoxSessionManager] Starting connection sequence for callId: ${effectCallId}`);
+      performingSessionManagementRef.current = true;
+      logger.log(`[UltravoxSessionManager] Starting connection sequence for callId: ${effectCallIdLog}`);
+      
+      // Set hasAttemptedConnectionRef to true before starting SDK operations for this attempt.
+      // This signifies that for the current callId/joinUrl, we are now making an attempt.
+      hasAttemptedConnectionRef.current = true;
+      logger.log(`[UltravoxSessionManager] Set hasAttemptedConnectionRef to true for callId: ${effectCallIdLog}`);
 
       try {
-        // 1. Pre-flight checks
         logger.log('[UltravoxSessionManager] Running pre-flight checks...');
         const { compatible, issues } = checkBrowserCompatibility();
-        if (!compatible) {
-          throw new Error(`Browser incompatible: ${issues.join(', ')}`);
-        }
+        if (!compatible) throw new Error(`Browser incompatible: ${issues.join(', ')}`);
         logger.log('[UltravoxSessionManager] Browser compatibility: OK');
 
         const micPerms = await checkMicrophonePermissions();
-        if (!micPerms.granted) {
-          throw new Error(micPerms.error || 'Microphone permission denied');
-        }
+        if (!micPerms.granted) throw new Error(micPerms.error || 'Microphone permission denied');
         logger.log('[UltravoxSessionManager] Microphone permissions: OK');
 
-        if (typeof WebSocket === 'undefined') {
-          throw new Error('WebSocket API not available in this browser');
-        }
+        if (typeof WebSocket === 'undefined') throw new Error('WebSocket API not available');
         logger.log('[UltravoxSessionManager] WebSocket API: OK');
 
-        // Optional: Test WebSocket connection (non-blocking for actual attempt)
         const wsTestSuccess = await testWebSocketConnection(joinUrl);
-        if (wsTestSuccess) {
-          logger.log('[UltravoxSessionManager] Preliminary WebSocket test: Successful');
-        } else {
-          logger.warn('[UltravoxSessionManager] Preliminary WebSocket test: Failed. Connection will still be attempted.');
-        }
+        if (wsTestSuccess) logger.log('[UltravoxSessionManager] Preliminary WebSocket test: Successful');
+        else logger.warn('[UltravoxSessionManager] Preliminary WebSocket test: Failed. Connection will still be attempted.');
+        
         logger.log('[UltravoxSessionManager] All pre-flight checks completed.');
 
-        // 2. Initialize and Connect
-        // Mark that we are about to attempt the actual connection via the hook
-        // This ref ensures we don't try to connect multiple times if shouldConnect remains true
-        hasAttemptedConnectionRef.current = true; 
-        
         await ultravoxSession.initializeSession();
-        logger.log('[UltravoxSessionManager] ultravoxSession.initializeSession() called.');
+        logger.log('[UltravoxSessionManager] ultravoxSession.initializeSession() succeeded.');
+        
+        // Check again if shouldConnect is still true after async initializeSession
+        if (!shouldConnect) {
+          logger.log('[UltravoxSessionManager] shouldConnect became false during initializeSession. Aborting connect.');
+          // Session was initialized, so it might need to be ended.
+          // endSession will be called by the main logic block when shouldConnect is false.
+          throw new Error('Connection aborted as shouldConnect turned false during initialization.');
+        }
         
         await ultravoxSession.connect(joinUrl);
-        logger.log('[UltravoxSessionManager] ultravoxSession.connect() called.');
+        logger.log('[UltravoxSessionManager] ultravoxSession.connect() succeeded.');
         
       } catch (error) {
         const errorMessage = error instanceof Error ? error.message : String(error);
-        logger.error(`[UltravoxSessionManager] Error during connection sequence for callId ${effectCallId}: ${errorMessage}`, error);
+        logger.error(`[UltravoxSessionManager] Error during connection sequence for callId ${effectCallIdLog}: ${errorMessage}`, error);
+        
+        hasEncounteredErrorRef.current = true; // Set error flag
+        logger.log(`[UltravoxSessionManager] Set hasEncounteredErrorRef to true for callId: ${effectCallIdLog}`);
         callbacks.onError(error instanceof Error ? error : new Error(errorMessage), 'ConnectionSetup');
-        // If pre-checks or connection fails, allow for a new attempt if props change
-        hasAttemptedConnectionRef.current = false; 
+        // DO NOT reset hasAttemptedConnectionRef here. It signifies an attempt was made for this callId/joinUrl.
+        // The hasEncounteredErrorRef will prevent immediate retries for this context.
       } finally {
-        performingPreChecksRef.current = false;
-        logger.log(`[UltravoxSessionManager] Connection sequence finished for callId: ${effectCallId}. performingPreChecksRef set to false.`);
+        performingSessionManagementRef.current = false;
+        logger.log(`[UltravoxSessionManager] Connection sequence finished for callId: ${effectCallIdLog}. performingSessionManagementRef set to false.`);
       }
     };
 
-    if (shouldConnect && !hasAttemptedConnectionRef.current) {
+    // Main logic for connecting or disconnecting
+    if (shouldConnect) {
       if (!joinUrl || !callId) {
         logger.warn('[UltravoxSessionManager] shouldConnect is true, but joinUrl or callId is missing. Waiting for valid props.');
-         if (performingPreChecksRef.current) performingPreChecksRef.current = false; // Reset if stuck
-      } else {
+        // Ensure performingSessionManagementRef is false if we bail out here, otherwise it might get stuck.
+        if (performingSessionManagementRef.current) performingSessionManagementRef.current = false;
+      } else if (!hasAttemptedConnectionRef.current && !hasEncounteredErrorRef.current) {
+        logger.log(`[UltravoxSessionManager] Conditions met for new connection attempt for callId: ${effectCallIdLog}. Starting sequence.`);
         performConnectionSequence();
+      } else if (hasAttemptedConnectionRef.current && hasEncounteredErrorRef.current) {
+        logger.log(`[UltravoxSessionManager] Connection previously attempted for callId ${effectCallIdLog} but encountered an error. Not retrying automatically.`);
+      } else if (hasAttemptedConnectionRef.current && !hasEncounteredErrorRef.current) {
+        logger.log(`[UltravoxSessionManager] Connection already attempted/active for callId ${effectCallIdLog} and no error encountered. No action needed.`);
+      } else {
+         logger.log(`[UltravoxSessionManager] shouldConnect is true, but other conditions not met for callId ${effectCallIdLog}. No action.`, 
+         { attempted: hasAttemptedConnectionRef.current, error: hasEncounteredErrorRef.current});
       }
-    } else if (!shouldConnect && hasAttemptedConnectionRef.current) {
-      logger.log(`[UltravoxSessionManager] shouldConnect is false and connection was active/attempted for callId ${effectCallId}. Ending session.`);
-      ultravoxSession.endSession();
-      hasAttemptedConnectionRef.current = false; // Reset, allowing re-connection if shouldConnect becomes true again.
-      if (performingPreChecksRef.current) performingPreChecksRef.current = false; // Reset if stuck
-    } else {
-      logger.log('[UltravoxSessionManager] No action taken by main effect (conditions not met or already handled).', { 
-         shouldConnect, hasAttempted: hasAttemptedConnectionRef.current, performingPreChecks: performingPreChecksRef.current 
-      });
-       if (performingPreChecksRef.current && !shouldConnect) { // Safety net: if prechecks were running but shouldConnect became false
-           performingPreChecksRef.current = false;
-           logger.warn('[UltravoxSessionManager] Reset performingPreChecksRef due to shouldConnect becoming false during prechecks.');
-       }
+    } else { // shouldConnect is false
+      if (hasAttemptedConnectionRef.current || hasEncounteredErrorRef.current) { // If there was any attempt or error for the current/previous session context
+        logger.log(`[UltravoxSessionManager] shouldConnect is false for callId ${effectCallIdLog}. Session was active, attempted, or had an error. Ending session and resetting flags.`);
+        if (!performingSessionManagementRef.current) { // Ensure not to interfere with an ongoing sequence
+            performingSessionManagementRef.current = true; // Guard this block
+            ultravoxSession.endSession().finally(() => {
+                performingSessionManagementRef.current = false;
+                logger.log(`[UltravoxSessionManager] endSession call finished in shouldConnect=false block for ${effectCallIdLog}.`);
+            });
+        } else {
+            logger.log(`[UltravoxSessionManager] endSession for ${effectCallIdLog} skipped as performSessionManagementRef is true.`);
+        }
+        hasAttemptedConnectionRef.current = false;
+        hasEncounteredErrorRef.current = false; // Reset error flag when explicitly disconnected
+        logger.log(`[UltravoxSessionManager] Reset hasAttemptedConnectionRef and hasEncounteredErrorRef for callId ${effectCallIdLog} due to shouldConnect being false.`);
+      } else {
+        logger.log(`[UltravoxSessionManager] shouldConnect is false for callId ${effectCallIdLog}, and no active/attempted session. No action needed.`);
+      }
+       // Safety reset for performingSessionManagementRef if it somehow got stuck true when shouldConnect is false
+      if (performingSessionManagementRef.current && !shouldConnect) {
+           performingSessionManagementRef.current = false;
+           logger.warn('[UltravoxSessionManager] Reset performingSessionManagementRef as shouldConnect is false and it was still true.');
+      }
     }
-  // Key dependencies:
-  // - shouldConnect: Primary driver for starting/stopping.
-  // - joinUrl, callId: If these change, a new session might be needed. Resetting hasAttemptedConnectionRef when shouldConnect is false allows this.
-  // - ultravoxSession: Provides stable methods from the hook.
-  // - callbacks: The hook itself manages callback stability with propsRef.
   }, [shouldConnect, joinUrl, callId, ultravoxSession, callbacks]);
 
   // Cleanup effect for component unmount
   useEffect(() => {
     return () => {
-      logger.log('[UltravoxSessionManager] Unmounting. Ensuring session is properly ended.');
+      const callIdLog = prevCallIdRef.current || callId || 'unknown-at-unmount';
+      logger.log(`[UltravoxSessionManager] Unmounting (callId: ${callIdLog}). Ensuring session is properly ended and flags reset.`);
+      // ultravoxSession.endSession() should be idempotent and handle if already disconnected.
       ultravoxSession.endSession();
-      // Explicitly reset refs on unmount to clear state for any potential remounts.
+      
+      // Explicitly reset all relevant refs on unmount
       hasAttemptedConnectionRef.current = false;
-      performingPreChecksRef.current = false;
+      performingSessionManagementRef.current = false;
+      hasEncounteredErrorRef.current = false;
+      prevJoinUrlRef.current = null; // Clear previous context tracking
+      prevCallIdRef.current = null;
+      logger.log(`[UltravoxSessionManager] All refs reset during unmount for callId: ${callIdLog}.`);
     };
-  }, [ultravoxSession]); // ultravoxSession object itself is stable
+  }, [ultravoxSession, callId]); // Include callId to log the correct one on unmount if it was available. ultravoxSession is stable.
 
   return (
     <div style={{ display: 'none' }} data-testid="ultravox-manager">


### PR DESCRIPTION
Fix: Resolve React Error #31 and Improve Ultravox Session Management

This commit addresses three main areas:

1.  **Resolves React Error #31 (Objects are not valid as a React child):**
    *   I've modified `useUltravoxSession.ts` to correctly extract the status string from the Ultravox SDK's 'status' event. The `handleStatus` (or equivalent) event handler now inspects the event object (checking `event.detail`, `event.detail.status`, `event.data`, etc.) and ensures that `props.onStatusChange` is called with a plain string as the primary status argument. This prevents an Event object from being passed into React state and rendered, which was the cause of the error.
    *   I've also verified that `page.tsx` and the Zustand store (`useAppState.ts`) correctly type and handle `uvClientStatus` as a string. No changes were needed in these files as they already adhered to this.

2.  **Refined Error Handling in `UltravoxSessionManager.tsx`:**
    *   I've introduced `hasEncounteredErrorRef` to track if an error has occurred during a connection attempt for the current session context (`joinUrl`, `callId`).
    *   Connection attempts are now gated by `!hasEncounteredErrorRef.current`, preventing automatic retries if a previous attempt for the same context failed.
    *   `hasAttemptedConnectionRef` is now set `true` at the start of a connection sequence and is not reset in the `catch` block for that same attempt.

3.  **Improved Re-entrancy Prevention in `UltravoxSessionManager.tsx`:**
    *   The manager now detects changes in `joinUrl` and `callId`. If these props change, `hasAttemptedConnectionRef` and `hasEncounteredErrorRef` are reset, allowing a fresh connection sequence for the new context.
    *   When `shouldConnect` transitions to `false`, or when the component unmounts, `hasAttemptedConnectionRef` and `hasEncounteredErrorRef` are reliably reset to `false`, ensuring a clean state for subsequent connection attempts.
    *   I've also enhanced logging to provide better visibility into state flag changes and decision-making processes.

Let me know if you have any questions about these changes!